### PR TITLE
Bugs #65 #66 fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Station coordinates are provided in longtitude/latitude pairs in decimal degrees
 
 There are no strict formating rules on how the individual elements should be printed (i.e. how many fields, decimal places, etc). The only condition is that fields are seperated by whitespace(s). To see an example of a valid input file, you can check `data/CNRS_midas.vel`.
 
-Note that when using the Shen method (aka --method='shen'), standard deviation values for north and east velocities (SigmaVe and SigmaVn) cannot be zero (see #65).
+Note that when using the Shen method (aka --method='shen'), standard deviation values for north and east velocities (SigmaVe and SigmaVn) cannot be zero (see [#65](https://github.com/DSOlab/StrainTool/issues/65)).
 
 ## Output Files
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Station coordinates are provided in longtitude/latitude pairs in decimal degrees
 
 There are no strict formating rules on how the individual elements should be printed (i.e. how many fields, decimal places, etc). The only condition is that fields are seperated by whitespace(s). To see an example of a valid input file, you can check `data/CNRS_midas.vel`.
 
+Note that when using the Shen method (aka --method='shen'), standard deviation values for north and east velocities (SigmaVe and SigmaVn) cannot be zero (see #65).
+
 ## Output Files
 
 Results of `StrainTensor.py` are recorded in the following three files:

--- a/bin/StrainTensor.py
+++ b/bin/StrainTensor.py
@@ -333,7 +333,12 @@ if __name__ == '__main__':
         print('[ERROR] Cannot find input file \'{}\'.'.format(
             args.gps_file), file=sys.stderr)
         sys.exit(1)
-    sta_list_ell = parse_ascii_input(args.gps_file)
+    try:
+        sta_list_ell = parse_ascii_input(args.gps_file, args.method=='shen')
+    except ValueError as err:
+        print(err)
+        print('[ERROR] Failed to parse input file: \"{:}\"'.format(args.gps_file))
+        sys.exit(1)
     print('[DEBUG] Reading station coordinates and velocities from {}'.format(
         args.gps_file))
     print('[DEBUG] Number of stations parsed: {}'.format(len(sta_list_ell)))

--- a/pystrain/pystrain/iotools/iparser.py
+++ b/pystrain/pystrain/iotools/iparser.py
@@ -1,31 +1,38 @@
 from pystrain.station import Station
 
-def parse_ascii_input(filename):
-    """Parse station info from an input file.
+def parse_ascii_input(filename, zero_std_is_error=False):
+  """Parse station info from an input file.
 
-        This function will try to read Stations of from the input file, named
-        filename. For this to work, the lines in the input file, should conform
-        to the following format:
-        "name lon lat Ve Vn Se Sn RHO T"
-        where lon and lat are in decimal degrees and velocity components and
-        sigmas are in mm/year.
-        For more information, see the functions:
-        Station.init_from_ascii_line()
-        Station.Station() --aka the constructor--.
+      This function will try to read Stations of from the input file, named
+      filename. For this to work, the lines in the input file, should conform
+      to the following format:
+      "name lon lat Ve Vn Se Sn RHO T"
+      where lon and lat are in decimal degrees and velocity components and
+      sigmas are in mm/year.
+      For more information, see the functions:
+      Station.init_from_ascii_line()
+      Station.Station() --aka the constructor--.
 
-        Args:
-            filename (string): the name of the file holding station info (see
-                               description above).
+      Args:
+          filename (string): the name of the file holding station info (see
+                             description above).
+          zero_std_is_error (bool): if set to True, then the function will throw
+                             if a station has zero std. deviation for either the
+                             north or east component (or both)
 
-        Returns:
-            list of Station instances or None (if no station was read)
+      Returns:
+          list of Station instances or None (if no station was read)
 
-    """
-    stations = []
-    with open(filename) as fin:
-        for line in fin.readlines():
-            stations.append(Station(line))
-    if len(stations):
-        return stations
-    else:
-        return None
+  """
+  stations = []
+  with open(filename) as fin:
+    for line in fin.readlines():
+      # stations.append(Station(line))
+      nSta=Station(line)
+      if zero_std_is_error and (nSta.sn==0e0 or nSta.se==0e0):
+        raise ValueError('[ERROR] Zero std. deviation not allowed! station is: {:}'.format(nSta.name))
+      stations.append(nSta)
+  if len(stations):
+    return stations
+  else:
+    return None

--- a/pystrain/pystrain/iotools/iparser.py
+++ b/pystrain/pystrain/iotools/iparser.py
@@ -31,6 +31,12 @@ def parse_ascii_input(filename, zero_std_is_error=False):
       nSta=Station(line)
       if zero_std_is_error and (nSta.sn==0e0 or nSta.se==0e0):
         raise ValueError('[ERROR] Zero std. deviation not allowed! station is: {:}'.format(nSta.name))
+      ## check that the station is not a duplicate
+      for sta in stations:
+        if sta.name == nSta.name:
+          raise ValueError('[ERROR] Duplicate record found in input file for station {:}'.format(sta.name))
+        if sta.lat==nSta.lat and sta.lon==nSta.lon:
+          raise ValueError('[ERROR] Exact coordinate match for stations {:} and {:}. Possible duplicate!'.format(sta.name, nSta.name))
       stations.append(nSta)
   if len(stations):
     return stations

--- a/pystrain/pystrain/station.py
+++ b/pystrain/pystrain/station.py
@@ -71,10 +71,9 @@ class Station:
         '''
         self.set_none()
 
-        if len(args) is not 0:
-            self.init_from_ascii_line(args[0])
+        if len(args) != 0: self.init_from_ascii_line(args[0])
 
-        if len(kargs) is not 0:
+        if len(kargs) != 0:
             for key, val in kargs.items():
                 if key in station_member_names:
                     setattr(self, key, val)

--- a/pystrain/pystrain/strain.py
+++ b/pystrain/pystrain/strain.py
@@ -967,7 +967,7 @@ class ShenStrain:
         """
         ##  If we are using Shen's weighting sheme, the find D, lweights and
         ##+ zweights.
-        if self.__options__['weighting_function'] is 'shen':
+        if self.__options__['weighting_function'] == 'shen':
             if not self.__options__['d_coef']:
                 self.vprint('[DEBUG] Searching for optimal D parameter.')
                 if self.__options__['dmin'] >= self.__options__['dmax'] or self.__options__['dstep'] < 0:


### PR DESCRIPTION
## Description 
#65 
ug is re-producible, but only affects Shen method (aka --method='shen'). Here is how we are going to solve this:

Function parse_ascii_input() in file pystrain/pystrain/iotools/iparser.py now takes one extra (bool) argument zero_std_is_error=False (has a default value of False). If set to True the function will throw (a ValueError) if a standard deviation value for either North or East component is set to zero (in the input file, for any station parsed). Why use this extra argument and not throw anyway? because the std. deviation values are only relevant for the Shen method; if the user has selected the Veis method, then we just ignore them anyway.
The call to parse_ascii_input() in bin/StrainTool.py is now changed to sta_list_ell = parse_ascii_input(args.gps_file, args.method=='shen') so that if a station with zero std. deviation (in north or east) is parsed when method='shen' is triggered, will result in an error and the program will exit!.

#66 
Quite a few funny things happen when we have duplicate lines!!!

So, here is how we are fixing this:
When parsing the stations from the input file via the function parse_ascii_input, we are (for each new station) checking that the new station parsed is NOT a duplicate (aka already in the list). This check is twofold, that is

we check that there is not other station already parsed with the same name, and
we check that there is not other station already parsed with the same longitude and latitude values
If either 1 or 2 hold, then we throw (a ValueError) and the program terminates.
Files changed:

pystrain/pystrain/iotools/iparser.py
Files changed:

pystrain/pystrain/iotools/iparser.py
bin/StrainTool.py

#### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


